### PR TITLE
chore: update CI workflows to trigger on closed pull requests only fo…

### DIFF
--- a/.github/workflows/dev-branch-validation-preview.yml
+++ b/.github/workflows/dev-branch-validation-preview.yml
@@ -1,15 +1,15 @@
 name: Dev Branch Validation & Android Preview Build
 
 on:
-  push:
-    branches:
-      - dev
   pull_request:
+    types:
+      - closed
     branches:
       - dev
 
 jobs:
   dev-validation:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,6 +35,7 @@ jobs:
         run: npm run type-check
 
   dev-unit-test:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     needs: dev-validation
     steps:
@@ -73,6 +74,7 @@ jobs:
           path: test-results/*
 
   dev-android-preview-build:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     needs: [dev-validation, dev-unit-test]
     steps:

--- a/.github/workflows/master-release-production.yml
+++ b/.github/workflows/master-release-production.yml
@@ -5,15 +5,15 @@
 name: Master Branch Release & Production Build
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
+    types:
+      - closed
     branches:
       - master
 
 jobs:
   master-release-production:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Master Branch Code


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to ensure that CI/CD jobs for both the `dev` and `master` branches only run after a pull request is closed and merged, rather than on every push. This change helps prevent unnecessary builds and validations for unmerged changes and aligns the automation more closely with the desired release flow.

**Workflow trigger changes:**

* [`.github/workflows/dev-branch-validation-preview.yml`](diffhunk://#diff-33ab27f0337007e3f5e805143d9740b3af0631fbcebf2b63408576acb52d7547L4-R12): Changed the trigger from `push` to `pull_request` with the type `closed` for the `dev` branch, and added a condition to run jobs only if the pull request is merged.
* [`.github/workflows/master-release-production.yml`](diffhunk://#diff-39dd0e13a1f64e127541635534ab3c32718bec1304f0719dd5fe988a408217e6L8-R16): Changed the trigger from `push` to `pull_request` with the type `closed` for the `master` branch, and added a condition to run jobs only if the pull request is merged.

**Job execution conditions:**

* [`.github/workflows/dev-branch-validation-preview.yml`](diffhunk://#diff-33ab27f0337007e3f5e805143d9740b3af0631fbcebf2b63408576acb52d7547L4-R12): Added `if: github.event.pull_request.merged == true` to the `dev-validation`, `dev-unit-test`, and `dev-android-preview-build` jobs to ensure they only run after a successful merge. [[1]](diffhunk://#diff-33ab27f0337007e3f5e805143d9740b3af0631fbcebf2b63408576acb52d7547L4-R12) [[2]](diffhunk://#diff-33ab27f0337007e3f5e805143d9740b3af0631fbcebf2b63408576acb52d7547R38) [[3]](diffhunk://#diff-33ab27f0337007e3f5e805143d9740b3af0631fbcebf2b63408576acb52d7547R77)
* [`.github/workflows/master-release-production.yml`](diffhunk://#diff-39dd0e13a1f64e127541635534ab3c32718bec1304f0719dd5fe988a408217e6L8-R16): Added `if: github.event.pull_request.merged == true` to the `master-release-production` job to ensure it only runs after a successful merge.…r dev and master branches